### PR TITLE
my.cnf had a typo for bind-address

### DIFF
--- a/my.cnf
+++ b/my.cnf
@@ -1,2 +1,2 @@
 [mysqld]
-bind-addres=0.0.0.0
+bind-address=0.0.0.0


### PR DESCRIPTION
Did running MySQL in it's own container work despite that?
