### PR TITLE
Update image to be based on trusty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:saucy
+FROM ubuntu:trusty
 MAINTAINER Fernando Mayo <fernando@tutum.co>
 
 # Install packages


### PR DESCRIPTION
To be able to add support for all mysql flavors of 14.04 as covered in #6, first make sure we base the image on Trusty (note: not tested this specifically).
