### PR TITLE
Remove supervisor from installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Fernando Mayo <fernando@tutum.co>, Feng Honglin <hfeng@tutum.co>
 
 # Install packages
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install supervisor mysql-server pwgen
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install mysql-server pwgen
 
 # Remove pre-installed database
 RUN rm -rf /var/lib/mysql/*


### PR DESCRIPTION
Since commit 842e12cf307f1ecd44913025f2c18819a221560e, supervisor is no longer used: mysqld is launched directly, supervisor configurations have been deleted and usages of supervisor have been removed from scripts.

I guess supervisor is not necessary and shouldn't be installed in the apt-get command.

(I noticed it because I wrote an tiny [article](http://pierre-jean.baraud.fr/blog/2014/05/19/deeper-look-dockerfile/) about your image )
