### PR TITLE
Use admin user for database import

### DIFF
--- a/import_sql.sh
+++ b/import_sql.sh
@@ -11,9 +11,9 @@ sleep 5
 echo "   Started with PID $!"
 
 echo "=> Importing SQL file"
-mysql -uroot -p"$1" < "$2"
+mysql -uadmin -p"$1" < "$2"
 
 echo "=> Stopping MySQL Server"
-mysqladmin -uroot -p"$1" shutdown
+mysqladmin -uadmin -p"$1" shutdown
 
 echo "=> Done!"


### PR DESCRIPTION
Admin user should be used for database import because you cannot use root + the password set with environment variable. (you set the password for admin so you should also use admin to import a database)
