### PR TITLE
Added extension hook for child images bootstrapping the database

### DIFF
--- a/5.5/run.sh
+++ b/5.5/run.sh
@@ -33,6 +33,14 @@ if [[ ! -d $VOLUME_HOME/mysql ]]; then
     echo "=> Done!"  
     echo "=> Creating admin user ..."
     /create_mysql_admin_user.sh
+    if [ -e "/boostrap.sh" ]; then
+        echo "=> Starting MySQL ..."
+        StartMySQL
+        echo "=> Executing bootstrap script..."
+        /bootstrap.sh
+        echo "=> Completed bootstrapping ..."
+        mysqladmin -uroot shutdown
+    fi
 else
     echo "=> Using an existing volume of MySQL"
 fi

--- a/5.6/run.sh
+++ b/5.6/run.sh
@@ -33,6 +33,14 @@ if [[ ! -d $VOLUME_HOME/mysql ]]; then
     echo "=> Done!"  
     echo "=> Creating admin user ..."
     /create_mysql_admin_user.sh
+    if [ -e "/boostrap.sh" ]; then
+        echo "=> Starting MySQL ..."
+        StartMySQL
+        echo "=> Executing bootstrap script..."
+        /bootstrap.sh
+        echo "=> Completed bootstrapping ..."
+        mysqladmin -uroot shutdown
+    fi
 else
     echo "=> Using an existing volume of MySQL"
 fi


### PR DESCRIPTION
For a project which needed the ability to quickly pull up a MySQL server with a certain pre-installed schema I added these extension hooks which allow child images to provide a "bootstrap.sh" script which is run on first boot...
