### PR TITLE
Removes syslog warning

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update && \
 # Remove pre-installed database
 RUN rm -rf /var/lib/mysql/*
 
+# Remove syslog configuration
+RUN rm /etc/mysql/conf.d/mysqld_safe_syslog.cnf
+
 # Add MySQL configuration
 ADD my.cnf /etc/mysql/conf.d/my.cnf
 ADD mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update && \
 # Remove pre-installed database
 RUN rm -rf /var/lib/mysql/*
 
+# Remove syslog configuration
+RUN rm /etc/mysql/conf.d/mysqld_safe_syslog.cnf
+
 # Add MySQL configuration
 ADD my.cnf /etc/mysql/conf.d/my.cnf
 ADD mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf


### PR DESCRIPTION
As you may have notice, there is a warning when starting the container:

```
mysqld_safe Can't log to error log and syslog at the same time.  Remove all --log-error configuration
```

This PR removes this warning.