### PR TITLE
FIX #63

### DIFF
--- a/5.6/run.sh
+++ b/5.6/run.sh
@@ -71,7 +71,7 @@ ImportSql()
 
 	for FILE in ${STARTUP_SQL}; do
 	   echo "=> Importing SQL file ${FILE}"
-	   mysql -uroot < "${FILE}"
+	   mysql -uroot ${ON_CREATE_DB} < "${FILE}"
 	done
 
 	mysqladmin -uroot shutdown


### PR DESCRIPTION
Supply the create db name by default when importing an sql script